### PR TITLE
Implement AJAX favorite toggle

### DIFF
--- a/app.py
+++ b/app.py
@@ -100,7 +100,7 @@ def favorite_courses():
 
 @app.route("/course/<course_code>/rating", methods=['POST'])
 def rating_course(course_code):
-  data = request.form
+  data = request.get_json() if request.is_json else request.form
   session_id = session.get('session_id')
   add_click_to_db(session_id, course_code, data)
   random_course_codes = session.get('random_course_codes')
@@ -123,14 +123,18 @@ def rating_course(course_code):
   if found_last_viewed:
     add_last_viewed_favorite_to_db(course_code)
 
+  if request.is_json:
+    return jsonify({"status": "ok", "favorited": True})
   previous_page = request.referrer
   return redirect(previous_page)
 
 @app.route("/course/<course_code>/remove_rating", methods=['POST'])
 def remove_rating(course_code):
-    data = request.form
+    data = request.get_json() if request.is_json else request.form
     session_id = session.get('session_id')
     add_click_to_db(session_id, course_code, data)
+    if request.is_json:
+        return jsonify({"status": "ok", "favorited": False})
     previous_page = request.referrer
     return redirect(previous_page)
 

--- a/static/favorite.js
+++ b/static/favorite.js
@@ -1,0 +1,32 @@
+// JavaScript to toggle course favourites without page reload
+
+function setupFavoriteForms() {
+  document.querySelectorAll('.favorite-form').forEach(function(form) {
+    form.addEventListener('submit', function(e) {
+      e.preventDefault();
+      const checkbox = form.querySelector('input[type="checkbox"]');
+      if (!checkbox) return;
+      const courseCode = checkbox.dataset.courseCode;
+      const favorited = checkbox.checked;
+      const url = favorited ? `/course/${courseCode}/rating` : `/course/${courseCode}/remove_rating`;
+      fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json'
+        },
+        body: JSON.stringify({ activity: favorited ? 'favorited' : 'unfavorited' })
+      }).then(function(resp) {
+        if (resp.ok) {
+          form.action = favorited ? `/course/${courseCode}/remove_rating` : `/course/${courseCode}/rating`;
+        } else {
+          checkbox.checked = !favorited;
+        }
+      }).catch(function() {
+        checkbox.checked = !favorited;
+      });
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', setupFavoriteForms);

--- a/templates/bootstrap.html
+++ b/templates/bootstrap.html
@@ -11,8 +11,11 @@
     <!-- FontAwesome CSS -->
     <script src="https://kit.fontawesome.com/78e15a0d97.js" crossorigin="anonymous"></script>
 
-    <!-- Bootstrap JS -->
+   <!-- Bootstrap JS -->
    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+
+    <!-- Favorite star handling -->
+    <script defer src="/static/favorite.js"></script>
 
     <!-- Frontend-joe -->
     <link

--- a/templates/coursepage.html
+++ b/templates/coursepage.html
@@ -179,24 +179,26 @@
       <div class="course-header">
         <h3 style="margin-right: 30px"><b>{{ course['course_name'] }}</b></h3>
         {% if course in favorite_courses %}
-          <form action="/course/{{ course['course_code'] }}/remove_rating" method="post">
+          <form class="favorite-form" action="/course/{{ course['course_code'] }}/remove_rating" method="post">
               <input type="hidden" name="activity" value="unfavorited">
               <label class="star">
                 <input type="checkbox"
-                      name="activity" 
-                      value="unfavorited"
-                      onchange="this.form.submit()"
-                      checked>
+                       name="activity"
+                       value="unfavorited"
+                       onchange="this.form.submit()"
+                       checked
+                       data-course-code="{{ course['course_code'] }}">
                 <svg height="24px" id="Layer_1" version="1.2" viewBox="0 0 24 24" width="24px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g><g><path d="M9.362,9.158c0,0-3.16,0.35-5.268,0.584c-0.19,0.023-0.358,0.15-0.421,0.343s0,0.394,0.14,0.521    c1.566,1.429,3.919,3.569,3.919,3.569c-0.002,0-0.646,3.113-1.074,5.19c-0.036,0.188,0.032,0.387,0.196,0.506    c0.163,0.119,0.373,0.121,0.538,0.028c1.844-1.048,4.606-2.624,4.606-2.624s2.763,1.576,4.604,2.625    c0.168,0.092,0.378,0.09,0.541-0.029c0.164-0.119,0.232-0.318,0.195-0.505c-0.428-2.078-1.071-5.191-1.071-5.191    s2.353-2.14,3.919-3.566c0.14-0.131,0.202-0.332,0.14-0.524s-0.23-0.319-0.42-0.341c-2.108-0.236-5.269-0.586-5.269-0.586    s-1.31-2.898-2.183-4.83c-0.082-0.173-0.254-0.294-0.456-0.294s-0.375,0.122-0.453,0.294C10.671,6.26,9.362,9.158,9.362,9.158z"></path></g></g></svg>
               </label>
           </form>
           {% else %}
-          <form action="/course/{{ course['course_code'] }}/rating" method="post">
+          <form class="favorite-form" action="/course/{{ course['course_code'] }}/rating" method="post">
               <label class="star">
-                <input type="checkbox" 
-                      name="activity" 
-                      value="favorited"
-                      onchange="this.form.submit()">
+                <input type="checkbox"
+                       name="activity"
+                       value="favorited"
+                       onchange="this.form.submit()"
+                       data-course-code="{{ course['course_code'] }}">
                 <svg height="24px" id="Layer_1" version="1.2" viewBox="0 0 24 24" width="24px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g><g><path d="M9.362,9.158c0,0-3.16,0.35-5.268,0.584c-0.19,0.023-0.358,0.15-0.421,0.343s0,0.394,0.14,0.521    c1.566,1.429,3.919,3.569,3.919,3.569c-0.002,0-0.646,3.113-1.074,5.19c-0.036,0.188,0.032,0.387,0.196,0.506    c0.163,0.119,0.373,0.121,0.538,0.028c1.844-1.048,4.606-2.624,4.606-2.624s2.763,1.576,4.604,2.625    c0.168,0.092,0.378,0.09,0.541-0.029c0.164-0.119,0.232-0.318,0.195-0.505c-0.428-2.078-1.071-5.191-1.071-5.191    s2.353-2.14,3.919-3.566c0.14-0.131,0.202-0.332,0.14-0.524s-0.23-0.319-0.42-0.341c-2.108-0.236-5.269-0.586-5.269-0.586    s-1.31-2.898-2.183-4.83c-0.082-0.173-0.254-0.294-0.456-0.294s-0.375,0.122-0.453,0.294C10.671,6.26,9.362,9.158,9.362,9.158z"></path></g></g></svg>
               </label>
           </form>

--- a/templates/star.html
+++ b/templates/star.html
@@ -1,23 +1,25 @@
 <div class="star-container">
   {% if course in favorite_courses %}
-  <form action="/course/{{ course['course_code'] }}/remove_rating" method="post">
+  <form class="favorite-form" action="/course/{{ course['course_code'] }}/remove_rating" method="post">
       <input type="hidden" name="activity" value="unfavorited">
       <label class="star">
         <input type="checkbox"
-               name="activity" 
+               name="activity"
                value="unfavorited"
                onchange="this.form.submit()"
-               checked>
+               checked
+               data-course-code="{{ course['course_code'] }}">
         <svg height="24px" id="Layer_1" version="1.2" viewBox="0 0 24 24" width="24px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g><g><path d="M9.362,9.158c0,0-3.16,0.35-5.268,0.584c-0.19,0.023-0.358,0.15-0.421,0.343s0,0.394,0.14,0.521    c1.566,1.429,3.919,3.569,3.919,3.569c-0.002,0-0.646,3.113-1.074,5.19c-0.036,0.188,0.032,0.387,0.196,0.506    c0.163,0.119,0.373,0.121,0.538,0.028c1.844-1.048,4.606-2.624,4.606-2.624s2.763,1.576,4.604,2.625    c0.168,0.092,0.378,0.09,0.541-0.029c0.164-0.119,0.232-0.318,0.195-0.505c-0.428-2.078-1.071-5.191-1.071-5.191    s2.353-2.14,3.919-3.566c0.14-0.131,0.202-0.332,0.14-0.524s-0.23-0.319-0.42-0.341c-2.108-0.236-5.269-0.586-5.269-0.586    s-1.31-2.898-2.183-4.83c-0.082-0.173-0.254-0.294-0.456-0.294s-0.375,0.122-0.453,0.294C10.671,6.26,9.362,9.158,9.362,9.158z"></path></g></g></svg>
       </label>
   </form>
   {% else %}
-  <form action="/course/{{ course['course_code'] }}/rating" method="post">
+  <form class="favorite-form" action="/course/{{ course['course_code'] }}/rating" method="post">
       <label class="star">
-        <input type="checkbox" 
-               name="activity" 
+        <input type="checkbox"
+               name="activity"
                value="favorited"
-               onchange="this.form.submit()">
+               onchange="this.form.submit()"
+               data-course-code="{{ course['course_code'] }}">
         <svg height="24px" id="Layer_1" version="1.2" viewBox="0 0 24 24" width="24px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g><g><path d="M9.362,9.158c0,0-3.16,0.35-5.268,0.584c-0.19,0.023-0.358,0.15-0.421,0.343s0,0.394,0.14,0.521    c1.566,1.429,3.919,3.569,3.919,3.569c-0.002,0-0.646,3.113-1.074,5.19c-0.036,0.188,0.032,0.387,0.196,0.506    c0.163,0.119,0.373,0.121,0.538,0.028c1.844-1.048,4.606-2.624,4.606-2.624s2.763,1.576,4.604,2.625    c0.168,0.092,0.378,0.09,0.541-0.029c0.164-0.119,0.232-0.318,0.195-0.505c-0.428-2.078-1.071-5.191-1.071-5.191    s2.353-2.14,3.919-3.566c0.14-0.131,0.202-0.332,0.14-0.524s-0.23-0.319-0.42-0.341c-2.108-0.236-5.269-0.586-5.269-0.586    s-1.31-2.898-2.183-4.83c-0.082-0.173-0.254-0.294-0.456-0.294s-0.375,0.122-0.453,0.294C10.671,6.26,9.362,9.158,9.362,9.158z"></path></g></g></svg>
       </label>
   </form>


### PR DESCRIPTION
## Summary
- add JavaScript helper to toggle favourite star without reloading
- include new script in the common bootstrap template
- mark favourite forms and add data attributes
- return JSON for AJAX requests in `rating_course` and `remove_rating`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_683f755555e483219679cc892b611180