### PR TITLE
Add login and profile pages

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Login</title>
+    {% include 'bootstrap.html' %}
+</head>
+<body>
+{% include 'navbar.html' %}
+<div class="container" style="max-width:500px;margin-top:60px;">
+    <div class="card p-4" style="background-color:#F2D398;border:2px solid #986B23;border-radius:10px;">
+        <h3 class="mb-3 text-center">Login</h3>
+        {% if error %}
+        <div class="alert alert-danger">{{ error }}</div>
+        {% endif %}
+        <form method="post">
+            <div class="mb-3">
+                <label class="form-label">Email</label>
+                <input type="email" class="form-control" name="email" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Password</label>
+                <input type="password" class="form-control" name="password" required>
+            </div>
+            <div class="d-grid gap-2">
+                <button type="submit" class="btn btn-primary custom-btn">Login</button>
+                <a class="btn btn-link" href="{{ url_for('register') }}">Register</a>
+            </div>
+        </form>
+    </div>
+</div>
+{% include 'footer.html' %}
+</body>
+</html>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -69,6 +69,18 @@
                 <li class="nav-item">
                     <a class="custom-text" href="/favourites"><i class="fa-solid fa-star" style="color: #000000;"></i><b>Favourites</b></a>
                 </li>
+                {% if session.get('user_id') %}
+                <li class="nav-item">
+                    <a class="custom-text" href="/profile"><i class="fa-solid fa-user" style="color: #000000;"></i><b>{{ session.get('user_name') }}</b></a>
+                </li>
+                <li class="nav-item">
+                    <a class="custom-text" href="/logout"><b>Logout</b></a>
+                </li>
+                {% else %}
+                <li class="nav-item">
+                    <a class="custom-text" href="/login"><b>Login</b></a>
+                </li>
+                {% endif %}
             </ul>
               <form class="d-flex" role="search" action="/search" method="GET">
                   <input class="form-control me-2" type="text" name="query" placeholder="Search courses" required autocomplete="off">

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Profile</title>
+    {% include 'bootstrap.html' %}
+</head>
+<body>
+{% include 'navbar.html' %}
+<div class="container" style="max-width:600px;margin-top:60px;">
+    <div class="card p-4" style="background-color:#F2D398;border:2px solid #986B23;border-radius:10px;">
+        <h3 class="mb-3">Profile</h3>
+        <form method="post">
+            <div class="mb-3">
+                <label class="form-label">Name</label>
+                <input type="text" class="form-control" name="name" value="{{ user['name'] }}">
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Email</label>
+                <input type="email" class="form-control" value="{{ user['email'] }}" disabled>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">New Password (optional)</label>
+                <input type="password" class="form-control" name="password">
+            </div>
+            <div class="d-grid gap-2">
+                <button type="submit" class="btn btn-primary custom-btn">Update</button>
+                <a href="{{ url_for('logout') }}" class="btn btn-link">Logout</a>
+            </div>
+        </form>
+    </div>
+    <div class="mt-4">
+        <h4>Favourite Courses</h4>
+        <ul class="list-group">
+        {% for course in favorite_courses %}
+            <li class="list-group-item"><a href="/course/{{ course['course_code'] }}">{{ course['course_name'] }}</a></li>
+        {% else %}
+            <li class="list-group-item">No favourites yet.</li>
+        {% endfor %}
+        </ul>
+    </div>
+</div>
+{% include 'footer.html' %}
+</body>
+</html>

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Register</title>
+    {% include 'bootstrap.html' %}
+</head>
+<body>
+{% include 'navbar.html' %}
+<div class="container" style="max-width:500px;margin-top:60px;">
+    <div class="card p-4" style="background-color:#F2D398;border:2px solid #986B23;border-radius:10px;">
+        <h3 class="mb-3 text-center">Register</h3>
+        {% if error %}
+        <div class="alert alert-danger">{{ error }}</div>
+        {% endif %}
+        <form method="post">
+            <div class="mb-3">
+                <label class="form-label">Name</label>
+                <input type="text" class="form-control" name="name" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Email</label>
+                <input type="email" class="form-control" name="email" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Password</label>
+                <input type="password" class="form-control" name="password" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Confirm Password</label>
+                <input type="password" class="form-control" name="confirm" required>
+            </div>
+            <div class="d-grid gap-2">
+                <button type="submit" class="btn btn-primary custom-btn">Register</button>
+                <a class="btn btn-link" href="{{ url_for('login') }}">Back to login</a>
+            </div>
+        </form>
+    </div>
+</div>
+{% include 'footer.html' %}
+</body>
+</html>

--- a/user_db.py
+++ b/user_db.py
@@ -1,0 +1,100 @@
+import sqlite3
+from werkzeug.security import generate_password_hash, check_password_hash
+
+DB_NAME = 'users.db'
+
+def init_db():
+    conn = sqlite3.connect(DB_NAME)
+    c = conn.cursor()
+    c.execute('''CREATE TABLE IF NOT EXISTS users (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    email TEXT NOT NULL UNIQUE,
+                    password TEXT NOT NULL
+                )''')
+    c.execute('''CREATE TABLE IF NOT EXISTS favorites (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER NOT NULL,
+                    course_code TEXT NOT NULL,
+                    UNIQUE(user_id, course_code)
+                )''')
+    conn.commit()
+    conn.close()
+
+
+def create_user(name, email, password):
+    conn = sqlite3.connect(DB_NAME)
+    c = conn.cursor()
+    password_hash = generate_password_hash(password)
+    c.execute('INSERT INTO users (name, email, password) VALUES (?, ?, ?)',
+              (name, email, password_hash))
+    conn.commit()
+    conn.close()
+
+
+def get_user_by_email(email):
+    conn = sqlite3.connect(DB_NAME)
+    conn.row_factory = sqlite3.Row
+    c = conn.cursor()
+    c.execute('SELECT * FROM users WHERE email = ?', (email,))
+    user = c.fetchone()
+    conn.close()
+    return user
+
+
+def get_user_by_id(user_id):
+    conn = sqlite3.connect(DB_NAME)
+    conn.row_factory = sqlite3.Row
+    c = conn.cursor()
+    c.execute('SELECT * FROM users WHERE id = ?', (user_id,))
+    user = c.fetchone()
+    conn.close()
+    return user
+
+
+def authenticate_user(email, password):
+    user = get_user_by_email(email)
+    if user and check_password_hash(user['password'], password):
+        return user
+    return None
+
+
+def update_user(user_id, name=None, password=None):
+    conn = sqlite3.connect(DB_NAME)
+    c = conn.cursor()
+    if name is not None:
+        c.execute('UPDATE users SET name = ? WHERE id = ?', (name, user_id))
+    if password:
+        password_hash = generate_password_hash(password)
+        c.execute('UPDATE users SET password = ? WHERE id = ?',
+                  (password_hash, user_id))
+    conn.commit()
+    conn.close()
+
+
+def add_favorite(user_id, course_code):
+    conn = sqlite3.connect(DB_NAME)
+    c = conn.cursor()
+    c.execute('INSERT OR IGNORE INTO favorites (user_id, course_code) VALUES (?, ?)',
+              (user_id, course_code))
+    conn.commit()
+    conn.close()
+
+
+def remove_favorite(user_id, course_code):
+    conn = sqlite3.connect(DB_NAME)
+    c = conn.cursor()
+    c.execute('DELETE FROM favorites WHERE user_id = ? AND course_code = ?',
+              (user_id, course_code))
+    conn.commit()
+    conn.close()
+
+
+def get_favorites(user_id):
+    conn = sqlite3.connect(DB_NAME)
+    conn.row_factory = sqlite3.Row
+    c = conn.cursor()
+    c.execute('SELECT course_code FROM favorites WHERE user_id = ?', (user_id,))
+    favorites = [row['course_code'] for row in c.fetchall()]
+    conn.close()
+    return favorites


### PR DESCRIPTION
## Summary
- create SQLite user database helpers
- implement login, register, logout and profile routes
- update rating and remove_rating to store favourites in SQLite when logged in
- add login, register and profile templates
- show login/profile links in navbar

## Testing
- `python -m py_compile app.py user_db.py`
- `python -m compileall -q .`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_683ffebc55308321a9a8da50ab483b7e